### PR TITLE
Add chain resolution feature to convert chains to standalone code

### DIFF
--- a/agi_agents_package/agi_agents/agi_agent.py
+++ b/agi_agents_package/agi_agents/agi_agent.py
@@ -543,7 +543,352 @@ class Agents:
             return chain, extracted_parameters
         else:
             return chain
-   
+
+    @staticmethod
+    def _resolve_model_info(model: Any) -> tuple:
+        """
+        Introspect a LangChain model object and return import/code strings.
+
+        Args:
+            model: A LangChain chat model instance.
+
+        Returns:
+            Tuple of (import_line, instantiation_code).
+        """
+        model_class_name = type(model).__name__
+
+        if isinstance(model, ChatOpenAI):
+            model_name = getattr(model, 'model_name', None) or getattr(model, 'model', 'gpt-4o-mini')
+            temperature = getattr(model, 'temperature', 0)
+            import_line = "from langchain_openai import ChatOpenAI"
+            code = (
+                f'model = ChatOpenAI(\n'
+                f'    model_name="{model_name}",\n'
+                f'    temperature={temperature},\n'
+                f'    api_key=os.getenv("OPENAI_API_KEY")\n'
+                f')'
+            )
+        elif isinstance(model, ChatAnthropic):
+            model_name = getattr(model, 'model', None) or getattr(model, 'model_name', 'claude-3-5-sonnet-20241022')
+            temperature = getattr(model, 'temperature', 0)
+            import_line = "from langchain_anthropic import ChatAnthropic"
+            code = (
+                f'model = ChatAnthropic(\n'
+                f'    model_name="{model_name}",\n'
+                f'    temperature={temperature},\n'
+                f'    api_key=os.getenv("ANTHROPIC_API_KEY")\n'
+                f')'
+            )
+        elif isinstance(model, ChatGoogleGenerativeAI):
+            model_name = getattr(model, 'model', 'gemini-pro')
+            temperature = getattr(model, 'temperature', 0)
+            import_line = "from langchain_google_genai import ChatGoogleGenerativeAI"
+            code = (
+                f'model = ChatGoogleGenerativeAI(\n'
+                f'    model="{model_name}",\n'
+                f'    temperature={temperature},\n'
+                f'    google_api_key=os.getenv("GOOGLE_API_KEY")\n'
+                f')'
+            )
+        else:
+            module = type(model).__module__
+            import_line = f"from {module} import {model_class_name}"
+            code = f'model = {model_class_name}()  # TODO: configure model parameters'
+
+        return import_line, code
+
+    @staticmethod
+    def _resolve_parser_info(output_parser: Any) -> tuple:
+        """
+        Introspect a LangChain output parser and return import/code strings.
+
+        Args:
+            output_parser: A LangChain output parser instance.
+
+        Returns:
+            Tuple of (import_line, instantiation_code).
+        """
+        parser_class_name = type(output_parser).__name__
+        parser_module = type(output_parser).__module__
+
+        if parser_class_name == 'StrOutputParser':
+            return (
+                "from langchain_core.output_parsers import StrOutputParser",
+                "output_parser = StrOutputParser()"
+            )
+        elif parser_class_name == 'JsonOutputParser':
+            pydantic_obj = getattr(output_parser, 'pydantic_object', None)
+            if pydantic_obj:
+                schema_name = pydantic_obj.__name__
+                return (
+                    "from langchain_core.output_parsers import JsonOutputParser",
+                    f"output_parser = JsonOutputParser(pydantic_object={schema_name})  # TODO: define {schema_name} Pydantic model"
+                )
+            return (
+                "from langchain_core.output_parsers import JsonOutputParser",
+                "output_parser = JsonOutputParser()"
+            )
+        elif parser_class_name == 'PydanticOutputParser':
+            pydantic_obj = getattr(output_parser, 'pydantic_object', None)
+            if pydantic_obj:
+                schema_name = pydantic_obj.__name__
+                return (
+                    "from langchain_core.output_parsers import PydanticOutputParser",
+                    f"output_parser = PydanticOutputParser(pydantic_object={schema_name})  # TODO: define {schema_name} Pydantic model"
+                )
+            return (
+                "from langchain_core.output_parsers import PydanticOutputParser",
+                "output_parser = PydanticOutputParser()  # TODO: add pydantic_object"
+            )
+        else:
+            return (
+                f"from {parser_module} import {parser_class_name}",
+                f"output_parser = {parser_class_name}()  # TODO: configure parser"
+            )
+
+    @staticmethod
+    def _resolve_prompt_info(prompt_template: Any) -> tuple:
+        """
+        Introspect a ChatPromptTemplate and return code string for prompt construction.
+
+        Args:
+            prompt_template: A LangChain ChatPromptTemplate instance.
+
+        Returns:
+            Tuple of (code_string, needs_system_import: bool, needs_human_import: bool).
+        """
+        lines = []
+        msg_var_names = []
+        needs_system_import = False
+        needs_human_import = False
+        image_counter = 0
+
+        for i, msg in enumerate(prompt_template.messages):
+            msg_type = type(msg).__name__
+
+            if msg_type == 'SystemMessagePromptTemplate':
+                needs_system_import = True
+                template_str = getattr(msg.prompt, 'template', '')
+                lines.append(
+                    f"system_msg = SystemMessagePromptTemplate.from_template(\n"
+                    f"    {repr(template_str)}\n"
+                    f")"
+                )
+                msg_var_names.append('system_msg')
+
+            elif msg_type == 'HumanMessagePromptTemplate':
+                needs_human_import = True
+                prompt_obj = msg.prompt
+
+                # Check if it's a list-based (multipart) prompt
+                if isinstance(prompt_obj, list):
+                    # Multipart: text + images
+                    parts = []
+                    for part in prompt_obj:
+                        part_type = type(part).__name__
+                        if hasattr(part, 'template'):
+                            # Text part
+                            parts.append({'text': part.template})
+                        elif hasattr(part, 'url'):
+                            # Image part
+                            image_counter += 1
+                            url_template = getattr(part, 'url', '')
+                            detail = getattr(part, 'detail', 'auto')
+                            parts.append({
+                                'type': 'image_url',
+                                'image_url': {
+                                    'url': str(url_template),
+                                    'detail': str(detail)
+                                }
+                            })
+                    var_name = f"human_msg_{i}"
+                    lines.append(
+                        f"{var_name} = HumanMessagePromptTemplate.from_template(\n"
+                        f"    {repr(parts)}\n"
+                        f")"
+                    )
+                    msg_var_names.append(var_name)
+
+                elif hasattr(prompt_obj, 'template'):
+                    template_str = prompt_obj.template
+                    # Detect if template contains image_url patterns
+                    if 'image_url' in template_str or 'base64' in template_str:
+                        image_counter += 1
+                        var_name = f"image_msg_{image_counter}"
+                        # Try to reconstruct the original template structure
+                        lines.append(
+                            f"{var_name} = HumanMessagePromptTemplate.from_template([\n"
+                            f"    {{\n"
+                            f'        "type": "image_url",\n'
+                            f'        "image_url": {{\n'
+                            f'            "url": {repr(template_str)},\n'
+                            f'            "detail": "auto"\n'
+                            f"        }}\n"
+                            f"    }}\n"
+                            f"])"
+                        )
+                        msg_var_names.append(var_name)
+                    else:
+                        var_name = f"text_msg"
+                        lines.append(
+                            f"{var_name} = HumanMessagePromptTemplate.from_template(\n"
+                            f"    [{{'text': {repr(template_str)}}}]\n"
+                            f")"
+                        )
+                        msg_var_names.append(var_name)
+                else:
+                    # Fallback: try to use repr of the prompt object
+                    var_name = f"msg_{i}"
+                    lines.append(
+                        f"{var_name} = {repr(msg)}  # TODO: verify this message template"
+                    )
+                    msg_var_names.append(var_name)
+            else:
+                # Unknown message type - try generic approach
+                var_name = f"msg_{i}"
+                if hasattr(msg, 'prompt') and hasattr(msg.prompt, 'template'):
+                    template_str = msg.prompt.template
+                    lines.append(
+                        f"{var_name} = {msg_type}.from_template(\n"
+                        f"    {repr(template_str)}\n"
+                        f")"
+                    )
+                else:
+                    lines.append(f"{var_name} = {repr(msg)}  # TODO: verify")
+                msg_var_names.append(var_name)
+
+        # Build ChatPromptTemplate.from_messages
+        msg_list_str = ", ".join(msg_var_names)
+        lines.append(
+            f"prompt = ChatPromptTemplate.from_messages(messages=[{msg_list_str}])"
+        )
+
+        code = "\n\n".join(lines)
+        return code, needs_system_import, needs_human_import
+
+    @staticmethod
+    def resolve(chain: Any) -> str:
+        """
+        Resolve a chain object into standalone LangChain Python code.
+
+        Takes a chain (RunnableSequence) created by chain_create and reverse-engineers
+        it into pure LangChain code with no dependency on the Agents class.
+
+        Args:
+            chain: A LangChain RunnableSequence (typically from chain_create).
+
+        Returns:
+            A string of valid Python code that recreates the equivalent chain
+            using only LangChain APIs directly.
+
+        Example:
+            >>> chain = Agents.chain_create(
+            ...     model=ChatOpenAI(model_name='gpt-4o-mini'),
+            ...     text_prompt_template="Answer: {question}",
+            ... )
+            >>> code = Agents.resolve(chain)
+            >>> print(code)  # Pure LangChain code, no Agents dependency
+        """
+        # --- Decompose the RunnableSequence ---
+        first = getattr(chain, 'first', None)
+        middle = getattr(chain, 'middle', [])
+        last = getattr(chain, 'last', None)
+
+        # Standard chain: prompt | model | parser
+        # first = prompt, middle = [model], last = parser
+        if middle:
+            prompt_template = first
+            model = middle[0]
+            output_parser = last
+        else:
+            # Two-step chain: prompt | model (no parser)
+            prompt_template = first
+            model = last
+            output_parser = None
+
+        # --- Introspect model ---
+        model_import, model_code = Agents._resolve_model_info(model)
+
+        # --- Introspect parser ---
+        if output_parser is not None:
+            parser_import, parser_code = Agents._resolve_parser_info(output_parser)
+        else:
+            parser_import = ""
+            parser_code = ""
+
+        # --- Introspect prompt template ---
+        prompt_code, needs_system, needs_human = Agents._resolve_prompt_info(prompt_template)
+
+        # --- Handle partial variables (format instructions) ---
+        partial_code = ""
+        if hasattr(prompt_template, 'partial_variables') and prompt_template.partial_variables:
+            for var_name, var_value in prompt_template.partial_variables.items():
+                if callable(var_value):
+                    partial_code += f'\nprompt = prompt.partial({var_name}=output_parser.get_format_instructions())'
+                else:
+                    partial_code += f'\nprompt = prompt.partial({var_name}={repr(var_value)})'
+
+        # --- Build chain composition ---
+        if output_parser is not None:
+            chain_code = "chain = prompt | model | output_parser"
+        else:
+            chain_code = "chain = prompt | model"
+
+        # --- Extract input variables for example usage ---
+        input_vars = getattr(prompt_template, 'input_variables', [])
+        # Filter out partial variables
+        partial_vars = set(getattr(prompt_template, 'partial_variables', {}).keys())
+        example_vars = [v for v in input_vars if v not in partial_vars]
+        example_dict = ", ".join(f'"{v}": "your_value_here"' for v in example_vars)
+
+        # --- Build prompt imports ---
+        prompt_imports = ["ChatPromptTemplate"]
+        if needs_human:
+            prompt_imports.append("HumanMessagePromptTemplate")
+        if needs_system:
+            prompt_imports.append("SystemMessagePromptTemplate")
+        prompt_import_str = (
+            "from langchain_core.prompts import (\n"
+            "    " + ",\n    ".join(prompt_imports) + ",\n"
+            ")"
+        )
+
+        # --- Assemble full code ---
+        sections = []
+        sections.append('"""Auto-generated standalone LangChain code.\nGenerated by Agents.resolve() - no agi_agents dependency required.\n"""')
+        sections.append("import os")
+        sections.append(model_import)
+        sections.append(prompt_import_str)
+        if parser_import:
+            sections.append(parser_import)
+
+        sections.append("")
+        sections.append("# --- Model Setup ---")
+        sections.append(model_code)
+
+        if parser_code:
+            sections.append("")
+            sections.append("# --- Output Parser ---")
+            sections.append(parser_code)
+
+        sections.append("")
+        sections.append("# --- Prompt Template ---")
+        sections.append(prompt_code)
+
+        if partial_code:
+            sections.append(partial_code)
+
+        sections.append("")
+        sections.append("# --- Chain Composition (LCEL) ---")
+        sections.append(chain_code)
+
+        sections.append("")
+        sections.append("# --- Example Usage ---")
+        sections.append(f"# response = chain.invoke({{{example_dict}}})")
+        sections.append("# print(response)")
+
+        return "\n".join(sections)
+
     @staticmethod
     async def _delay(seconds: float) -> None:
         """


### PR DESCRIPTION
## Summary
This PR adds a new `resolve()` method to the `Agents` class that converts LangChain chain objects into standalone, executable Python code with no dependency on the agi_agents package. This enables users to export chains created with the Agents API as pure LangChain code.

## Key Changes
- **Added `resolve()` static method**: Main entry point that decomposes a RunnableSequence chain and generates equivalent standalone LangChain code
- **Added `_resolve_model_info()` helper**: Introspects LangChain model objects (ChatOpenAI, ChatAnthropic, ChatGoogleGenerativeAI) and extracts import statements and instantiation code with proper configuration
- **Added `_resolve_parser_info()` helper**: Introspects output parsers (StrOutputParser, JsonOutputParser, PydanticOutputParser) and generates their import/instantiation code
- **Added `_resolve_prompt_info()` helper**: Introspects ChatPromptTemplate objects and reconstructs prompt template code, handling:
  - SystemMessagePromptTemplate and HumanMessagePromptTemplate
  - Multipart prompts with text and images
  - Template variables and partial variables
  - Complex image_url patterns

## Implementation Details
- The `resolve()` method decomposes chains into their constituent parts (prompt, model, parser) by accessing the RunnableSequence's `first`, `middle`, and `last` attributes
- Generated code includes proper imports, environment variable handling for API keys, and example usage comments
- Handles edge cases like chains without parsers and prompts with partial variables
- Output is formatted as a complete, runnable Python script with documentation
- Supports introspection of both standard and custom LangChain components with fallback handling

https://claude.ai/code/session_01RmwZUnSgC5dxjhTcbLaMvm